### PR TITLE
build: remove build-phar.sh for WordPress compliance

### DIFF
--- a/upload-field-to-youtube-for-acf/include_from.txt
+++ b/upload-field-to-youtube-for-acf/include_from.txt
@@ -11,6 +11,7 @@
 + src/**
 + vendor/
 - vendor/bin/
+- vendor/paragonie/random_compat/build-phar.sh
 - vendor/symfony/console/Resources/
 + vendor/**
 + composer.json


### PR DESCRIPTION
# Quick Fix

## Description
remove build-phar.sh for WordPress compliance

## Type
- [ ] Bug fix
- [ ] New feature  
- [ ] Documentation
- [x] Code quality/refactor